### PR TITLE
slight tweak to the 480i whitelist

### DIFF
--- a/to_configs/all/runcommand-onstart.sh
+++ b/to_configs/all/runcommand-onstart.sh
@@ -1,4 +1,4 @@
-if [ -f "/opt/retropie/configs/$1/480i.txt" ]; then interlaced=$(tr -d "\r" < "/opt/retropie/configs/$1/480i.txt"); fi > /dev/null
-if [ -f "/opt/retropie/configs/ports/$1/480i.txt" ]; then interlaced=$(tr -d "\r" < "/opt/retropie/configs/ports/$1/480i.txt"); fi > /dev/null
+if [ -f "/opt/retropie/configs/$1/480i.txt" ]; then interlaced=$(tr -d "\r" < "/opt/retropie/configs/$1/480i.txt" | sed -e 's/\[/\\\[/'); fi > /dev/null
+if [ -f "/opt/retropie/configs/ports/$1/480i.txt" ]; then interlaced=$(tr -d "\r" < "/opt/retropie/configs/ports/$1/480i.txt" | sed -e 's/\[/\\\[/'); fi > /dev/null
 if [ ! -s "/opt/retropie/configs/$1/480i.txt" ] && [ ! -s "/opt/retropie/configs/ports/$1/480i.txt" ] || [ -z "$interlaced" ]; then interlaced="none"; fi > /dev/null
-if tvservice -s | grep NTSC && ! echo "$3" | grep -wi "$interlaced" && ! echo "$interlaced" | grep -wi "all"; then tvservice -c "NTSC 4:3 P"; fbset -depth 8 -yres 400; fbset -depth 32; fi > /dev/null
+if tvservice -s | grep NTSC && ! echo "$3" | grep -wi "$interlaced" && ! echo "$interlaced" | grep -xi "all"; then tvservice -c "NTSC 4:3 P"; fbset -depth 8 -yres 400; fbset -depth 32; fi > /dev/null


### PR DESCRIPTION
this should make it detect square brackets.
also put a more strict rule for the "all" wildcard, previously it would give positive if "all" was followed by a hyphen "-". useful for games with "all-stars" or similar in its name.