### PR TITLE
new 240p whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,13 @@ of the system with a list with the file name (case insensitive, extension option
 of the games you want to force 480i.</br>
 if you want to force 480i for a whole system you can
 write _all_ inside the _480i.txt_ file.</br>
-this can also be used to set 480i in kodi.
+this can also be used to set 480i in kodi.</br>
+alternatively you can create a _240p.txt_ file to force 480i to all games BUT the onces inside the list.
 
 example: _configs/psx/480i.txt_ containing _Bloody Roar 2.pbp_ to force 480i only to _Bloody Roar 2_</br>
 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;_configs/psx/480i.txt_ containing _all_ to force 480i for all the PlayStation games.</br>
-&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;_configs/ports/kodi/480i.txt_ containing _all_ to force 480i in Kodi.
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;_configs/ports/kodi/480i.txt_ containing _all_ to force 480i in Kodi.</br>
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;_configs/dreamcast/240p.txt_ containing _Street Fighter III_ to force 480i to all games but Street Fighter III.
 
 #### how to use:
 - it is recommended to use a fresh installation of retropie but isn't mandatory.

--- a/to_configs/all/runcommand-onstart.sh
+++ b/to_configs/all/runcommand-onstart.sh
@@ -1,4 +1,7 @@
 if [ -f "/opt/retropie/configs/$1/480i.txt" ]; then interlaced=$(tr -d "\r" < "/opt/retropie/configs/$1/480i.txt" | sed -e 's/\[/\\\[/'); fi > /dev/null
 if [ -f "/opt/retropie/configs/ports/$1/480i.txt" ]; then interlaced=$(tr -d "\r" < "/opt/retropie/configs/ports/$1/480i.txt" | sed -e 's/\[/\\\[/'); fi > /dev/null
-if [ ! -s "/opt/retropie/configs/$1/480i.txt" ] && [ ! -s "/opt/retropie/configs/ports/$1/480i.txt" ] || [ -z "$interlaced" ]; then interlaced="none"; fi > /dev/null
-if tvservice -s | grep NTSC && ! echo "$3" | grep -wi "$interlaced" && ! echo "$interlaced" | grep -xi "all"; then tvservice -c "NTSC 4:3 P"; fbset -depth 8 -yres 448; fbset -depth 32; fi > /dev/null
+if [ ! -s "/opt/retropie/configs/$1/480i.txt" ] && [ ! -s "/opt/retropie/configs/ports/$1/480i.txt" ] || [ -z "$interlaced" ]; then interlaced="empty"; fi > /dev/null
+if [ -f "/opt/retropie/configs/$1/240p.txt" ]; then progresive=$(tr -d "\r" < "/opt/retropie/configs/$1/240p.txt" | sed -e 's/\[/\\\[/'); fi > /dev/null
+if [ -f "/opt/retropie/configs/ports/$1/240p.txt" ]; then progresive=$(tr -d "\r" < "/opt/retropie/configs/ports/$1/240p.txt" | sed -e 's/\[/\\\[/'); fi > /dev/null
+if [ ! -s "/opt/retropie/configs/$1/240p.txt" ] && [ ! -s "/opt/retropie/configs/ports/$1/240p.txt" ] || [ -z "$progresive" ]; then progresive="empty"; fi > /dev/null
+if tvservice -s | grep NTSC && { ! echo "$3" | grep -wi "$interlaced" || echo "$interlaced" | grep empty; } && ! echo "$interlaced" | grep -xi "all" && { echo "$3" | grep -wi "$progresive" || echo "$progresive" | grep empty; }; then tvservice -c "NTSC 4:3 P"; fbset -depth 8 -yres 448; fbset -depth 32; fi > /dev/null


### PR DESCRIPTION
a 240p.txt list can be created now that switches to 240p ONLY for the games that are in the list. good for dreamcast and pc98.